### PR TITLE
Enable quotes option on gulp-minify-html

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,9 @@ gulp.task('html-build', function() {
       anonymizeIp: false,
       linkAttribution: true,
       }))
-    .pipe(minifyHTML())
+    .pipe(minifyHTML({
+      quotes: true
+    }))
     .pipe(gulp.dest(build.html));
 });
 


### PR DESCRIPTION
If it's false, gulp-minify-html destroy OGP tags.